### PR TITLE
Add pokemon past Glastrier such as Gen 9, existing pokemon forms

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,7 +22,7 @@ const TYPE_IDS = {
 
 async function fetchPokemonList() {
     try {
-        const response = await axios.get(`${POKEAPI_URL}/pokemon?limit=898`);
+        const response = await axios.get(`${POKEAPI_URL}/pokemon?limit=99999`);
         const pokemonList = response.data.results.map((pokemon, index) => ({
             name: pokemon.name,
             url: pokemon.url,


### PR DESCRIPTION
Playing around with the API call limit brings up more Pokemon and forms, which I noticed were missing (namely Fezandipiti and co). Eventually more Pokemon and forms will be added, so adding a higher limit would be nice catch all

Interestingly, the call ends at 1025 for Pecharunt then picks up again at 10001 for alternate forms like Megas and regionals. Highlight of  returned response:
```
...
{"name":"regidrago","url":"https://pokeapi.co/api/v2/pokemon/895/"},{"name":"glastrier","url":"https://pokeapi.co/api/v2/pokemon/896/"},{"name":"spectrier","url":"https://pokeapi.co/api/v2/pokemon/897/"},{"name":"calyrex","url":"https://pokeapi.co/api/v2/pokemon/898/"},{"name":"wyrdeer","url":"https://pokeapi.co/api/v2/pokemon/899/"},
...,
{"name":"fuecoco","url":"https://pokeapi.co/api/v2/pokemon/909/"},
...,
{"name":"roaring-moon","url":"https://pokeapi.co/api/v2/pokemon/1005/"
...,
{"name":"pecharunt","url":"https://pokeapi.co/api/v2/pokemon/1025/"},{"name":"deoxys-attack","url":"https://pokeapi.co/api/v2/pokemon/10001/"},
...,
{"name":"kangaskhan-mega","url":"https://pokeapi.co/api/v2/pokemon/10039/"},
...
,{"name":"decidueye-hisui","url":"https://pokeapi.co/api/v2/pokemon/10244/"},{"name":"dialga-origin","url":"https://pokeapi.co/api/v2/pokemon/10245/"}.
..,{"name":"terapagos-stellar","url":"https://pokeapi.co/api/v2/pokemon/10277/"}]}
```

https://pokeapi.co/api/v2/pokemon?limit=99999